### PR TITLE
Module id working with det-poc

### DIFF
--- a/pentaho-flat-table-viz/impl/src/main/javascript/web/flat-table-viz/model.js
+++ b/pentaho-flat-table-viz/impl/src/main/javascript/web/flat-table-viz/model.js
@@ -28,8 +28,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
     return BaseModel.extend({
       type: {
-        //id: "pentaho-flat-table-viz-impl_7.0-SNAPSHOT/flat-table-viz", //det-poc
-        id: moduleId,
+        id: "pentaho-flat-table-viz-impl/7-0-SNAPSHOT/flat-table-viz", //det-poc
         view: view,
         label: 'Flat Table',
         isBrowsable: true,


### PR DESCRIPTION
Since the det-poc is the only project where we have drop zones, this branch is needed to allow QA to test the integration of the columns visual role on the viz.
Currently the viz module id needs to be defined differently (hardcoded) to work within det-poc.
